### PR TITLE
Fixing build for Visual Studio

### DIFF
--- a/src/components/candevice/candevice.h
+++ b/src/components/candevice/candevice.h
@@ -18,7 +18,7 @@ class CanDevice : public QObject
 public:
     CanDevice();
     ~CanDevice();
-    bool init(const QString &backend, const QString &interface);
+    bool init(const QString &backend, const QString &iface);
     bool start();
 
 Q_SIGNALS:

--- a/tests/example.cpp
+++ b/tests/example.cpp
@@ -1,5 +1,4 @@
 #include <candevice/candevice.h>
-// Keep fakeit as a last include. Otherwise it may cause compilation errors on Windows. 
 #define CATCH_CONFIG_RUNNER
 #include <fakeit.hpp>
 


### PR DESCRIPTION
On Windows catch uses a 'interface' name for some reasons hence we can't
name variables with that label as this causes a compiled error under
Windows